### PR TITLE
feat: Add `group_libraries` lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,8 @@ packages/
     - be a valid entry point placed in `lib/` or `bin/` directory and named `main.dart`, `main_<flavor>.dart` or `<packageName>.dart`
     - or placed within the `app`, `libraries` or `features` folder contained in the `lib/` or `lib/src/` folder.
 </details>
+<details>
+  <summary>group_libraries</summary>
+
+  - Ensures that files within the `libraries` folder are grouped into another folder.
+</details>

--- a/example/apps/example_app/lib/src/libraries/library_b.dart
+++ b/example/apps/example_app/lib/src/libraries/library_b.dart
@@ -1,0 +1,2 @@
+// expect_lint: group_libraries
+class LibraryB {}

--- a/lib/alf_lints.dart
+++ b/lib/alf_lints.dart
@@ -1,4 +1,5 @@
 import 'package:alf_lints/src/features/group_alf_lint.dart';
+import 'package:alf_lints/src/features/group_libraries_lint.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 PluginBase createPlugin() => _AlfLinter();
@@ -7,5 +8,6 @@ class _AlfLinter extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
         GroupAlfLint(),
+        GroupLibrariesLint(),
       ];
 }

--- a/lib/src/features/group_alf_lint.dart
+++ b/lib/src/features/group_alf_lint.dart
@@ -1,7 +1,7 @@
-import 'package:alf_lints/src/libraries/constants/folders.dart';
+import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
 import 'package:alf_lints/src/libraries/file_path/get_relative_package_path.dart';
 import 'package:alf_lints/src/libraries/file_path/is_entry_point_path.dart';
-import 'package:alf_lints/src/libraries/file_path/is_path_of_type.dart';
+import 'package:alf_lints/src/libraries/file_path/is_path_of_domain.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -28,9 +28,9 @@ Name entry point `main.dart`, `main_<flavor>.dart` or `<package-name>.dart`.''',
     final relativePath = getRelativePackagePath(fullPath);
 
     if (isEntryPointPath(fullPath, packageName: context.pubspec.name)) return;
-    if (isPathOfType(relativePath, Folders.features)) return;
-    if (isPathOfType(relativePath, Folders.libraries)) return;
-    if (isPathOfType(relativePath, Folders.app)) return;
+    if (isPathOfDomain(relativePath, FileDomain.features)) return;
+    if (isPathOfDomain(relativePath, FileDomain.libraries)) return;
+    if (isPathOfDomain(relativePath, FileDomain.app)) return;
 
     bool reported = false;
     context.registry.addAnnotatedNode((node) {

--- a/lib/src/features/group_libraries_lint.dart
+++ b/lib/src/features/group_libraries_lint.dart
@@ -1,0 +1,37 @@
+import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
+import 'package:alf_lints/src/libraries/file_path/get_relative_package_path.dart';
+import 'package:alf_lints/src/libraries/file_path/is_grouped_within_domain.dart';
+import 'package:alf_lints/src/libraries/file_path/is_path_of_domain.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+class GroupLibrariesLint extends DartLintRule {
+  const GroupLibrariesLint() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'group_libraries',
+    problemMessage: 'Group libraries.',
+    correctionMessage: 'Group libraries into folders.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    final fullPath = resolver.source.fullName;
+    final relativePath = getRelativePackagePath(fullPath);
+
+    if (!isPathOfDomain(relativePath, FileDomain.libraries)) return;
+    if (isGroupedWithinDomain(relativePath, FileDomain.libraries)) return;
+
+    bool reported = false;
+    context.registry.addAnnotatedNode((node) {
+      if (reported) return;
+
+      reporter.reportErrorForNode(code, node);
+      reported = true;
+    });
+  }
+}

--- a/lib/src/libraries/constants/folders.dart
+++ b/lib/src/libraries/constants/folders.dart
@@ -1,7 +1,0 @@
-abstract class Folders {
-  const Folders._();
-
-  static get app => 'app';
-  static get features => 'features';
-  static get libraries => 'libraries';
-}

--- a/lib/src/libraries/file_path/file_domain.dart
+++ b/lib/src/libraries/file_path/file_domain.dart
@@ -1,0 +1,9 @@
+enum FileDomain {
+  app('app/'),
+  features('features/'),
+  libraries('libraries/');
+
+  final String path;
+
+  const FileDomain(this.path);
+}

--- a/lib/src/libraries/file_path/get_domain_groups.dart
+++ b/lib/src/libraries/file_path/get_domain_groups.dart
@@ -1,0 +1,14 @@
+import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
+import 'package:alf_lints/src/libraries/file_path/is_path_of_domain.dart';
+
+/// Returns the domain groups determined by the [relativePath] and the [domain]'s path.
+/// Returns an empty array if the [domain] does not exist for teh given [relativePath].
+/// Examples:
+/// - `features/example_feature.dart` for domain `features` would return ["example_feature.dart"]
+/// - `features/a/b/c/example_feature.dart` for domain `features` would return an array consisting of "a", "b", "c" and "example_feature.dart"
+/// - `features/a/b/c/example_feature.dart` for domain `libraries` would return an empty array
+List<String> getDomainGroups(String? relativePath, FileDomain domain) {
+  if (relativePath == null) return [];
+  if (!isPathOfDomain(relativePath, domain)) return [];
+  return relativePath.split(domain.path).last.split('/');
+}

--- a/lib/src/libraries/file_path/is_grouped_within_domain.dart
+++ b/lib/src/libraries/file_path/is_grouped_within_domain.dart
@@ -1,0 +1,6 @@
+import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
+import 'package:alf_lints/src/libraries/file_path/get_domain_groups.dart';
+
+/// Returns `true` if the content of domain is grouped within a directory.
+bool isGroupedWithinDomain(String? relativePath, FileDomain domain) =>
+    getDomainGroups(relativePath, domain).length > 1;

--- a/lib/src/libraries/file_path/is_path_of_domain.dart
+++ b/lib/src/libraries/file_path/is_path_of_domain.dart
@@ -1,0 +1,5 @@
+import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
+
+/// Returns `true` if the [relativePath] starts in a directory named like the [domain]'s path or false in case it's `null`.
+bool isPathOfDomain(String? relativePath, FileDomain domain) =>
+    relativePath?.startsWith(domain.path) ?? false;

--- a/lib/src/libraries/file_path/is_path_of_type.dart
+++ b/lib/src/libraries/file_path/is_path_of_type.dart
@@ -1,3 +1,0 @@
-/// Returns `true` if the [relativePath] starts in a directory named [type] or false in case it's `null`.
-bool isPathOfType(String? relativePath, String type) =>
-    relativePath?.startsWith('$type/') ?? false;


### PR DESCRIPTION
Warns if files inside `libraries` are not grouped by at least one folder.