### PR TITLE
Fix analyzer setup

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,4 +2,5 @@ include: package:lints/recommended.yaml
 
 linter:
   rules:
+    - prefer_relative_imports
     - require_trailing_commas

--- a/example/apps/example_app/analysis_options.yaml
+++ b/example/apps/example_app/analysis_options.yaml
@@ -6,4 +6,5 @@ analyzer:
 
 linter:
   rules:
+    - prefer_relative_imports
     - require_trailing_commas

--- a/example/apps/example_app/lib/main.dart
+++ b/example/apps/example_app/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:example_app/src/app/routes.dart';
+import 'src/app/routes.dart';
 
 class Main {
   final Routes routes;

--- a/example/apps/example_app/lib/src/features/a/feature_a.dart
+++ b/example/apps/example_app/lib/src/features/a/feature_a.dart
@@ -1,5 +1,5 @@
 // expect_lint: avoid_import_app_from_feature
-import 'package:example_app/src/app/pages/page_a.dart';
+import '../../app/pages/page_a.dart';
 
 class FeatureA {
   final PageA pageA;

--- a/lib/alf_lints.dart
+++ b/lib/alf_lints.dart
@@ -1,7 +1,8 @@
-import 'package:alf_lints/src/features/avoid_import_app_from_feature_lint.dart';
-import 'package:alf_lints/src/features/group_alf_lint.dart';
-import 'package:alf_lints/src/features/group_libraries_lint.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import 'src/features/avoid_import_app_from_feature_lint.dart';
+import 'src/features/group_alf_lint.dart';
+import 'src/features/group_libraries_lint.dart';
 
 PluginBase createPlugin() => _AlfLinter();
 

--- a/lib/src/features/avoid_import_app_from_feature_lint.dart
+++ b/lib/src/features/avoid_import_app_from_feature_lint.dart
@@ -1,9 +1,10 @@
-import 'package:alf_lints/src/libraries/analyzer/import_directive_x.dart';
-import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
-import 'package:alf_lints/src/libraries/file_path/get_relative_package_path.dart';
-import 'package:alf_lints/src/libraries/file_path/is_path_of_domain.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import '../libraries/analyzer/import_directive_x.dart';
+import '../libraries/file_path/file_domain.dart';
+import '../libraries/file_path/get_relative_package_path.dart';
+import '../libraries/file_path/is_path_of_domain.dart';
 
 class AvoidImportAppFromFeatureLint extends DartLintRule {
   const AvoidImportAppFromFeatureLint() : super(code: _code);

--- a/lib/src/features/group_alf_lint.dart
+++ b/lib/src/features/group_alf_lint.dart
@@ -1,9 +1,10 @@
-import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
-import 'package:alf_lints/src/libraries/file_path/get_relative_package_path.dart';
-import 'package:alf_lints/src/libraries/file_path/is_entry_point_path.dart';
-import 'package:alf_lints/src/libraries/file_path/is_path_of_domain.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import '../libraries/file_path/file_domain.dart';
+import '../libraries/file_path/get_relative_package_path.dart';
+import '../libraries/file_path/is_entry_point_path.dart';
+import '../libraries/file_path/is_path_of_domain.dart';
 
 class GroupAlfLint extends DartLintRule {
   const GroupAlfLint() : super(code: _code);

--- a/lib/src/features/group_libraries_lint.dart
+++ b/lib/src/features/group_libraries_lint.dart
@@ -1,9 +1,10 @@
-import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
-import 'package:alf_lints/src/libraries/file_path/get_relative_package_path.dart';
-import 'package:alf_lints/src/libraries/file_path/is_grouped_within_domain.dart';
-import 'package:alf_lints/src/libraries/file_path/is_path_of_domain.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import '../libraries/file_path/file_domain.dart';
+import '../libraries/file_path/get_relative_package_path.dart';
+import '../libraries/file_path/is_grouped_within_domain.dart';
+import '../libraries/file_path/is_path_of_domain.dart';
 
 class GroupLibrariesLint extends DartLintRule {
   const GroupLibrariesLint() : super(code: _code);

--- a/lib/src/libraries/analyzer/import_directive_x.dart
+++ b/lib/src/libraries/analyzer/import_directive_x.dart
@@ -1,7 +1,8 @@
-import 'package:alf_lints/src/libraries/file_path/get_package_identifier.dart';
-import 'package:alf_lints/src/libraries/file_path/get_package_name.dart';
-import 'package:alf_lints/src/libraries/file_path/get_relative_package_path.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+
+import '../file_path/get_package_identifier.dart';
+import '../file_path/get_package_name.dart';
+import '../file_path/get_relative_package_path.dart';
 
 extension ImportDirectiveX on ImportDirective {
   String? get fullPath => element?.importedLibrary?.source.fullName;

--- a/lib/src/libraries/file_path/get_domain_groups.dart
+++ b/lib/src/libraries/file_path/get_domain_groups.dart
@@ -1,5 +1,5 @@
-import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
-import 'package:alf_lints/src/libraries/file_path/is_path_of_domain.dart';
+import 'file_domain.dart';
+import 'is_path_of_domain.dart';
 
 List<String> getDomainGroups(String? relativePath, FileDomain domain) {
   if (relativePath == null) return [];

--- a/lib/src/libraries/file_path/get_package_identifier.dart
+++ b/lib/src/libraries/file_path/get_package_identifier.dart
@@ -1,4 +1,4 @@
-import 'package:alf_lints/src/libraries/file_path/get_package_path.dart';
+import 'get_package_path.dart';
 
 String? getPackageIdentifier(String? fullPath) => getPackagePath(fullPath)
     ?.split('/')

--- a/lib/src/libraries/file_path/is_grouped_within_domain.dart
+++ b/lib/src/libraries/file_path/is_grouped_within_domain.dart
@@ -1,5 +1,5 @@
-import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
-import 'package:alf_lints/src/libraries/file_path/get_domain_groups.dart';
+import 'file_domain.dart';
+import 'get_domain_groups.dart';
 
 bool isGroupedWithinDomain(String? relativePath, FileDomain domain) =>
     getDomainGroups(relativePath, domain).length > 1;

--- a/lib/src/libraries/file_path/is_path_of_domain.dart
+++ b/lib/src/libraries/file_path/is_path_of_domain.dart
@@ -1,4 +1,4 @@
-import 'package:alf_lints/src/libraries/file_path/file_domain.dart';
+import 'file_domain.dart';
 
 bool isPathOfDomain(String? relativePath, FileDomain domain) =>
     relativePath?.startsWith(domain.path) ?? false;


### PR DESCRIPTION
Excluding the example package from top level `analysis_options.yaml` caused the example package to not work as expected anymore (e.g. auto-importing in VSCode did not work anymore).

Having imports via `package:` within the example app did cause even more trouble within the current CI test setup.
Somehow the main package analyzed the example app (and failed), while analyzing the example app succeeded.
Could not be reproduced locally.