### PR TITLE
feat: Add `avoid_import_app_from_library` lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ packages/
 </details>
 
 <details>
+  <summary>avoid_import_app_from_library</summary>
+
+  - Ensures that libraries don't import composing app code.
+</details>
+
+<details>
   <summary>group_alf</summary>
 
   - Ensures that files are placed and named according to the alf-linting conventions. Files should either

--- a/example/apps/example_app/lib/src/libraries/a/library_a.dart
+++ b/example/apps/example_app/lib/src/libraries/a/library_a.dart
@@ -1,1 +1,8 @@
-class LibraryA {}
+// expect_lint: avoid_import_app_from_library
+import '../../app/pages/page_a.dart';
+
+class LibraryA {
+  final PageA pageA;
+
+  LibraryA(this.pageA);
+}

--- a/lib/alf_lints.dart
+++ b/lib/alf_lints.dart
@@ -1,6 +1,7 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 import 'src/features/avoid_import_app_from_feature_lint.dart';
+import 'src/features/avoid_import_app_from_library_lint.dart';
 import 'src/features/group_alf_lint.dart';
 import 'src/features/group_libraries_lint.dart';
 
@@ -10,6 +11,7 @@ class _AlfLinter extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
         AvoidImportAppFromFeatureLint(),
+        AvoidImportAppFromLibraryLint(),
         GroupAlfLint(),
         GroupLibrariesLint(),
       ];

--- a/lib/src/features/avoid_import_app_from_library_lint.dart
+++ b/lib/src/features/avoid_import_app_from_library_lint.dart
@@ -1,0 +1,38 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import '../libraries/analyzer/import_directive_x.dart';
+import '../libraries/file_path/file_domain.dart';
+import '../libraries/file_path/get_relative_package_path.dart';
+import '../libraries/file_path/is_path_of_domain.dart';
+
+class AvoidImportAppFromLibraryLint extends DartLintRule {
+  const AvoidImportAppFromLibraryLint() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_import_app_from_library',
+    problemMessage: 'Avoid app import from library.',
+    correctionMessage: '''
+Consider extracting the referenced code into a shared library.''',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    final fullPath = resolver.source.fullName;
+    final relativePath = getRelativePackagePath(fullPath);
+
+    if (!isPathOfDomain(relativePath, FileDomain.libraries)) return;
+
+    context.registry.addImportDirective((node) {
+      final importPath = node.relativePath;
+
+      if (!isPathOfDomain(importPath, FileDomain.app)) return;
+
+      reporter.reportErrorForNode(code, node);
+    });
+  }
+}


### PR DESCRIPTION
Ensures that libraries don't import composing app code