### PR TITLE
feat: Add `avoid_import_entry_point` lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ packages/
 </details>
 
 <details>
+  <summary>avoid_import_entry_point</summary>
+
+  - Ensures that no code imports entry points.
+</details>
+
+<details>
   <summary>group_alf</summary>
 
   - Ensures that files are placed and named according to the alf-linting conventions. Files should either

--- a/example/apps/example_app/lib/src/app/app.dart
+++ b/example/apps/example_app/lib/src/app/app.dart
@@ -1,8 +1,8 @@
 // expect_lint: avoid_import_entry_point
 import '../../main.dart';
 
-class Routes {
+class App {
   final Main main;
 
-  const Routes(this.main);
+  const App(this.main);
 }

--- a/example/apps/example_app/lib/src/features/a/feature_a.dart
+++ b/example/apps/example_app/lib/src/features/a/feature_a.dart
@@ -1,8 +1,11 @@
+// expect_lint: avoid_import_entry_point
+import '../../../main.dart';
 // expect_lint: avoid_import_app_from_feature
 import '../../app/pages/page_a.dart';
 
 class FeatureA {
+  final Main main;
   final PageA pageA;
 
-  const FeatureA(this.pageA);
+  const FeatureA(this.main, this.pageA);
 }

--- a/example/apps/example_app/lib/src/libraries/a/library_a.dart
+++ b/example/apps/example_app/lib/src/libraries/a/library_a.dart
@@ -1,8 +1,11 @@
+// expect_lint: avoid_import_entry_point
+import '../../../main.dart';
 // expect_lint: avoid_import_app_from_library
 import '../../app/pages/page_a.dart';
 
 class LibraryA {
+  final Main main;
   final PageA pageA;
 
-  LibraryA(this.pageA);
+  const LibraryA(this.main, this.pageA);
 }

--- a/example/apps/example_app/lib/src/other/other.dart
+++ b/example/apps/example_app/lib/src/other/other.dart
@@ -1,0 +1,16 @@
+// expect_lint: avoid_import_entry_point, group_alf
+import '../../example_app.dart';
+// expect_lint: avoid_import_entry_point
+import '../../main.dart';
+// expect_lint: avoid_import_entry_point
+import '../../main_dev.dart';
+import '../no_entry_point.dart';
+
+class Other {
+  final ExampleApp exampleApp;
+  final Main main;
+  final MainDev mainDev;
+  final NoEntryPoint noEntryPoint;
+
+  const Other(this.exampleApp, this.main, this.mainDev, this.noEntryPoint);
+}

--- a/lib/alf_lints.dart
+++ b/lib/alf_lints.dart
@@ -2,6 +2,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 import 'src/features/avoid_import_app_from_feature_lint.dart';
 import 'src/features/avoid_import_app_from_library_lint.dart';
+import 'src/features/avoid_import_entry_point_lint.dart';
 import 'src/features/group_alf_lint.dart';
 import 'src/features/group_libraries_lint.dart';
 
@@ -12,6 +13,7 @@ class _AlfLinter extends PluginBase {
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
         AvoidImportAppFromFeatureLint(),
         AvoidImportAppFromLibraryLint(),
+        AvoidImportEntryPointLint(),
         GroupAlfLint(),
         GroupLibrariesLint(),
       ];

--- a/lib/src/features/avoid_import_entry_point_lint.dart
+++ b/lib/src/features/avoid_import_entry_point_lint.dart
@@ -1,0 +1,31 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import '../libraries/analyzer/import_directive_x.dart';
+import '../libraries/file_path/is_entry_point_path.dart';
+
+class AvoidImportEntryPointLint extends DartLintRule {
+  const AvoidImportEntryPointLint() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_import_entry_point',
+    problemMessage: 'Avoid entry point import.',
+    correctionMessage: 'Only import from `app`, `libraries` or `features`.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    final packageName = context.pubspec.name;
+
+    context.registry.addImportDirective((node) {
+      if (node.isExternalPackageImport) return;
+      if (!isEntryPointPath(node.fullPath, packageName: packageName)) return;
+
+      reporter.reportErrorForNode(code, node);
+    });
+  }
+}

--- a/lib/src/libraries/file_path/is_entry_point_path.dart
+++ b/lib/src/libraries/file_path/is_entry_point_path.dart
@@ -1,2 +1,3 @@
-bool isEntryPointPath(final String fullPath, {required String packageName}) =>
+bool isEntryPointPath(final String? fullPath, {required String packageName}) =>
+    fullPath != null &&
     RegExp('(bin|lib)/(main|main_.*?|$packageName).dart\$').hasMatch(fullPath);

--- a/test/src/libraries/file_path/is_entry_point_path_test.dart
+++ b/test/src/libraries/file_path/is_entry_point_path_test.dart
@@ -5,6 +5,13 @@ void main() {
   group('isEntryPointPath', () {
     const packageName = 'some_package_name';
 
+    test('should return `false` when the full path is `null`', () {
+      expect(
+        isEntryPointPath(null, packageName: packageName),
+        isFalse,
+      );
+    });
+
     test(
         'should return `false` when the full path does not point to a valid entry point',
         () {


### PR DESCRIPTION
Ensures that no code imports entry points