### PR TITLE
docs: Remove assumptions about local package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,11 @@ packages/
 │  ├─ <my-feature>/
 │  │  ├─ lib/
 │  │  │  ├─ src/
-│  │  │  │  ├─ app/
-│  │  │  │  ├─ features/
-│  │  │  │  ├─ libraries/
 │  │  │  ├─ <my-feature>.dart
 ├─ libraries/
 │  ├─ <my-library>/
 │  │  ├─ lib/
 │  │  │  ├─ src/
-│  │  │  │  ├─ app/
-│  │  │  │  ├─ features/
-│  │  │  │  ├─ libraries/
 │  │  │  ├─ <my-library>.dart
 ```
 


### PR DESCRIPTION
It's kind of irritating to have this kind of nested alf-linting. It's up to the user how to structure local packages.